### PR TITLE
simplify constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # brazil-fiscal-client
 
-The base SOAP client of this lib is designed to be inherited by specialized clients such
-as for electronic invoicing (NFe). But it can still be used alone.
+The base SOAP fiscal client of this lib is designed to be inherited by specialized
+clients such as for electronic invoicing (NFe). But it can still be used alone.
 
 It uses [xsdata](https://github.com/tefra/xsdata) for the
 [databinding](https://xsdata.readthedocs.io/en/latest/data_binding/basics/) and it
@@ -19,7 +19,7 @@ status:
 
 ```python
 
-from brazil_fiscal_client.soap_client import SoapClient
+from brazil_fiscal_client.fiscal_client import FiscalClient
 from tests.fixtures.nfestatusservico4 import NfeStatusServico4SoapNfeStatusServicoNf
 from nfelib.nfe.bindings.v4_0.cons_stat_serv_v4_00 import ConsStatServ
 from nfelib.nfe.bindings.v4_0.ret_cons_stat_serv_v4_00 import RetConsStatServ
@@ -27,14 +27,13 @@ from nfelib.nfe.bindings.v4_0.ret_cons_stat_serv_v4_00 import RetConsStatServ
 ambiente = "2"
 uf = "41"
 
-with open("/path_to_your_certificate/some_pkcs12_certificate.p12", "rb") as pkcs12_data:
-    client = SoapClient.from_service(
-        NfeStatusServico4SoapNfeStatusServicoNf,
-        server="https://nfe-homologacao.svrs.rs.gov.br",
+with open("/path_to_your_certificate/some_pkcs12_certificate.p12", "rb") as pkcs12_buffer:
+    client = FiscalClient(
         uf=uf,
         ambiente=ambiente,
-        pkcs12_data=pkcs12_data.read(),
+        pkcs12_data=pkcs12_buffer.read(),
         pkcs12_password="your_certificate_password",
+        server="https://nfe-homologacao.svrs.rs.gov.br",
     )
 
 result = client.send(
@@ -46,10 +45,11 @@ result = client.send(
         versao="4.00",
     ),
 )
->>> print(result)
-RetConsStatServ(tpAmb=<Tamb.VALUE_2: '2'>, verAplic='SVRS202401251654', cStat='107', xMotivo='Servico SVC em Operacao', cUF=<TcodUfIbge.VALUE_41: '41'>, dhRecbto='2024-04-01T14:54:30-03:00', tMed='1', dhRetorno=None, xObs=None, versao='4.00')
->>> print(result.cStat)
-107
+
+>>> result
+RetConsStatServ(tpAmb=<Tamb.VALUE_2: '2'>, verAplic='SVRS202401251654', cStat='107', xMotivo='Servico SVC em Operacao', cUF=<TcodUfIbge.VALUE_41: '41'>, dhRecbto='2024-04-01T16:18:03-03:00', tMed='1', dhRetorno=None, xObs=None, versao='4.00')
+>>> result.cStat
+'107'
 ```
 
 Notice this example uses the `ConsStatServ` and `RetConsStatServ` bindings from

--- a/tests/test_fiscal_client.py
+++ b/tests/test_fiscal_client.py
@@ -1,9 +1,8 @@
 from unittest import TestCase, mock
 
-from xsdata.formats.dataclass.client import Config
 from xsdata.formats.dataclass.transports import DefaultTransport
 
-from brazil_fiscal_client.soap_client import SoapClient as Client
+from brazil_fiscal_client.fiscal_client import FiscalClient
 from tests.fixtures.cons_stat_serv_v4_00 import ConsStatServ
 from tests.fixtures.nfestatusservico4 import NfeStatusServico4SoapNfeStatusServicoNf
 from tests.fixtures.ret_cons_stat_serv_v4_00 import RetConsStatServ
@@ -29,54 +28,39 @@ response = """<?xml version="1.0" encoding="utf-8"?>
 """
 
 
-class ClientTests(TestCase):
+class FiscalClientTests(TestCase):
     def test__init__(self):
-        config = Config.from_service(
-            NfeStatusServico4SoapNfeStatusServicoNf, transport="foobar"
-        )
-        client = Client(config)
-        self.assertIsInstance(client, Client)
-
-        # TODO FIXME
-        # this seems to be due to the workaround with Client.__slots__ ...
-        # self.assertIs(client.parser.context, client.serializer.context)
-        #
-        # client = Client(config, parser=XmlParser())
-        # self.assertIs(client.parser.context, client.serializer.context)
-        #
-        # client = Client(config, serializer=XmlSerializer())
-        # self.assertIs(client.parser.context, client.serializer.context)
-
-    def test_from_service(self):
-        client = Client.from_service(
-            NfeStatusServico4SoapNfeStatusServicoNf,
-            location="http://testurl.com",
+        client = FiscalClient(
+            ambiente="2",
             uf="41",
             pkcs12_data=b"fake_cert",
             pkcs12_password="123456",
+            server="http://testurl.com",
             fake_certificate=True,
         )
         self.assertEqual(client.uf, "41")
         self.assertEqual(client.pkcs12_data, b"fake_cert")
         self.assertEqual(client.pkcs12_password, "123456")
+        self.assertEqual(client.server, "http://testurl.com")
+        self.assertIs(client.parser.context, client.serializer.context)
 
     @mock.patch.object(DefaultTransport, "post")
     def test_send_with_instance_object(self, mock_post):
         mock_post.return_value = response.encode()
 
-        client = Client.from_service(
-            NfeStatusServico4SoapNfeStatusServicoNf,
-            location="http://testurl.com",
+        client = FiscalClient(
+            ambiente="2",
             uf=41,
             pkcs12_data=b"fake_cert",
             pkcs12_password="123456",
+            server="http://testurl.com",
             fake_certificate=True,
         )
 
         result = client.send(
             NfeStatusServico4SoapNfeStatusServicoNf,
             ConsStatServ(
-                tpAmb="1",
+                tpAmb="2",
                 cUF="41",
                 xServ="STATUS",
                 versao="4.00",


### PR DESCRIPTION
Rename SoapClient to FiscalClient.

Also use the FiscalClient rather than the from_service factory. Indeed, we tend to use a single client for several SOAP actions so using the from_service factory was overkill and useless for us.