### PR TITLE
Fix FiscalClient repr crash when UF is omitted

### DIFF
--- a/brazil_fiscal_client/fiscal_client.py
+++ b/brazil_fiscal_client/fiscal_client.py
@@ -129,6 +129,7 @@ class FiscalClient(Client):
             self.ambiente = ambiente
         else:
             self.ambiente = ambiente.value
+        self.uf = None
         if isinstance(uf, str):
             if uf not in [t.value for t in TcodUfIbge]:
                 raise ValueError(f"Invalid uf value: {uf}")

--- a/tests/test_client_repr.py
+++ b/tests/test_client_repr.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+
+from brazil_fiscal_client.fiscal_client import FiscalClient, Tamb
+
+
+class FiscalClientReprTests(TestCase):
+    def test_repr_works_without_uf(self):
+        client = FiscalClient(
+            ambiente=Tamb.DEV,
+            versao="4.00",
+            pkcs12_data=b"fake_cert",
+            pkcs12_password="123456",
+            fake_certificate=True,
+        )
+
+        self.assertEqual(
+            repr(client),
+            "<FiscalClient(ambiente=2, uf=None, service=nfe, versao=4.00)>",
+        )


### PR DESCRIPTION
### Motivation
- Prevent an `AttributeError` in `FiscalClient.__repr__` when the optional `uf` parameter is not provided, since the instance should still be representable.

### Description
- Initialize `self.uf = None` early in `FiscalClient.__init__` and add a regression test `tests/test_client_repr.py` that asserts `repr(client)` works when `uf` is omitted.

### Testing
- Ran `pytest -q tests/test_client_repr.py` which passed; ran full `pytest -q` which failed during collection due to a missing external dependency (`ModuleNotFoundError: No module named 'nfelib'`) that is unrelated to this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7d0d0c70833183ca9a64a31683a1)